### PR TITLE
Maybe type classes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,8 @@
     "purescript-prelude": "^3.1.0",
     "purescript-foreign-generic": "^5.0.0",
     "purescript-typelevel-prelude": "^2.4.0",
-    "purescript-record": "^0.2.0"
+    "purescript-record": "^0.2.0",
+    "purescript-nullable": "^3.0.0"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",

--- a/src/Simple/JSON.js
+++ b/src/Simple/JSON.js
@@ -1,0 +1,3 @@
+"use strict";
+
+exports["null"] = null;

--- a/src/Simple/JSON.js
+++ b/src/Simple/JSON.js
@@ -1,3 +1,0 @@
-"use strict";
-
-exports["null"] = null;

--- a/src/Simple/JSON.purs
+++ b/src/Simple/JSON.purs
@@ -27,6 +27,7 @@ import Data.Foreign.Internal (readStrMap)
 import Data.Foreign.JSON (parseJSON)
 import Data.Foreign.NullOrUndefined (NullOrUndefined(NullOrUndefined), readNullOrUndefined, unNullOrUndefined, undefined)
 import Data.Maybe (Maybe(..), maybe)
+import Data.Nullable (toNullable)
 import Data.Record (get, insert)
 import Data.StrMap as StrMap
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
@@ -166,9 +167,7 @@ instance writeForeignNullOrUndefined :: WriteForeign a => WriteForeign (NullOrUn
 
 instance writeForeignMaybe :: WriteForeign a => WriteForeign (Maybe a) where
   writeImpl (Just a) = writeImpl a
-  writeImpl Nothing = null
-
-foreign import null :: Foreign
+  writeImpl Nothing = toForeign $ toNullable Nothing 
 
 instance writeForeignStrMap :: WriteForeign a => WriteForeign (StrMap.StrMap a) where
   writeImpl = toForeign <<< StrMap.mapWithKey (const writeImpl)

--- a/src/Simple/JSON.purs
+++ b/src/Simple/JSON.purs
@@ -22,18 +22,16 @@ import Prelude
 
 import Control.Monad.Except (withExcept)
 import Data.Foreign (F, Foreign, ForeignError(..), readArray, readBoolean, readChar, readInt, readNumber, readString, toForeign)
-import Data.Foreign as Foreign
 import Data.Foreign.Index (readProp)
 import Data.Foreign.Internal (readStrMap)
 import Data.Foreign.JSON (parseJSON)
-import Data.Foreign.NullOrUndefined (NullOrUndefined(NullOrUndefined), readNullOrUndefined, undefined)
+import Data.Foreign.NullOrUndefined (NullOrUndefined(NullOrUndefined), readNullOrUndefined, unNullOrUndefined, undefined)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Record (get, insert)
 import Data.StrMap as StrMap
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
-import Data.Traversable (sequence, traverse)
+import Data.Traversable (sequence)
 import Global.Unsafe (unsafeStringify)
-
 import Type.Prelude (class TypeEquals, to)
 import Type.Row (class ListToRow, class RowLacks, class RowToList, Cons, Nil, RLProxy(RLProxy), RProxy(..), kind RowList)
 
@@ -94,7 +92,7 @@ instance readNullOrUndefined :: ReadForeign a => ReadForeign (NullOrUndefined a)
   readImpl = readNullOrUndefined readImpl
 
 instance readMaybe :: ReadForeign a => ReadForeign (Maybe a) where
-  readImpl foreignValue = (Foreign.readNullOrUndefined foreignValue) >>= (traverse readImpl)
+  readImpl = map unNullOrUndefined <<< readImpl
 
 instance readStrMap :: ReadForeign a => ReadForeign (StrMap.StrMap a) where
   readImpl = sequence <<< StrMap.mapWithKey (const readImpl) <=< readStrMap

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -69,8 +69,8 @@ type MyTestManyMaybe =
 roundtrips :: forall a. ReadForeign a => WriteForeign a => Proxy a -> String -> Aff (RunnerEffects ()) Unit
 roundtrips _ enc0 = do
   let dec0 :: E a
-      dec0 = handleJSON $ enc0
-      enc1 = either (const "bad1") writeJSON $ dec0
+      dec0 = handleJSON enc0
+      enc1 = either (const "bad1") writeJSON dec0
       json0 :: Either String Json
       json0 = jsonParser enc0
       json1 :: Either String Json

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,13 +10,11 @@ import Data.Argonaut.Parser (jsonParser)
 import Data.Either (Either(..), either, fromLeft, isRight)
 import Data.Foreign (ForeignError(..), MultipleErrors)
 import Data.Foreign.NullOrUndefined (NullOrUndefined)
-import Data.Generic (class Generic)
 import Data.List (List(..))
 import Data.List.NonEmpty (NonEmptyList(..))
-import Data.Maybe (Maybe(..))
+import Data.Maybe (Maybe)
 import Data.NonEmpty (NonEmpty(..))
 import Data.StrMap (StrMap)
-import Debug.Trace (spy)
 import Partial.Unsafe (unsafePartial)
 import Simple.JSON (class ReadForeign, class WriteForeign, readJSON, writeJSON)
 import Test.Spec (describe, it)
@@ -118,6 +116,6 @@ main = run [consoleReporter] do
     it "works with Maybe field and null value" $ roundtrips (Proxy :: Proxy MyTestMaybe) """
         { "a": null }
       """ 
-    it "works with a several Maybe fields" $ roundtrips (Proxy :: Proxy MyTestManyMaybe) """
+    it "works with many Maybe fields" $ roundtrips (Proxy :: Proxy MyTestManyMaybe) """
       { "a": "str", "aNull": null, "b":1, "bNull": null, "c":true, "cNull":null, "d":1.1, "dNull":null, "e":["str1", "str2", null], "eNull": null }
     """ 


### PR DESCRIPTION
Hi I enjoy using this library. It's really reduced a lot of boilerplate for me, so thanks so much for putting it together!

One thing that I wish it had out of the box is type class instances for `Maybe`. Using NullOrUndefined feels a bit leaky to me, and wrapping my `Maybe`s in `newtype`s just to get the functionality I wanted was becoming fairly tedious since I use `Maybe` so much. I also noticed there some similar sentiment on the latest PureScript Unscripted, so I decided to make this PR.

Things to note:
* when reading json, fields with `Maybe` types that have corresponding json values that are `null` or `undefined` will decode to a `Nothing`. Otherwise it will be `Just value`
* when writing `fieldName :: Just value` to json, the resulting json will be `"fieldName":"value"`, and when writing `fieldName :: Nothing`, the resulting json will be `"fieldName":null`
* I've added a foreign import to allow `null` to be written to the resulting json, and because I did that I didn't want it leaking out of the module, so I've added all of the relevant functions as exports.
* I've added four additional tests to test the edge cases and standard cases. 

Hope that you find this helpful. If you'd like any changes, I'm happy to make them!