### PR TITLE
Alternative variant encoding

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -147,7 +147,7 @@ main = do
 
   -- "works with Variant"
   roundtrips (Proxy :: Proxy MyTestVariant) """
-    { "type": "b", "value": 123  }
+    { "b": 123  }
   """
 
   -- run examples


### PR DESCRIPTION
This implementation represent variants as a single-member JSON object. This is closer to the idea of variants using the same structural system as records.

The goal is to improve communication between PureScript and APIs written in languages that can't model sum types, and fall back to records with null-values.