### PR TITLE
Fixes for PureScript 0.14.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,19 +12,17 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^4.1.1",
-    "purescript-typelevel-prelude": "^5.0.0",
-    "purescript-record": "^2.0.1",
-    "purescript-variant": "^6.0.1",
-    "purescript-nullable": "^4.1.1",
-    "purescript-foreign-object": "^2.0.3",
-    "purescript-globals": "^4.0.0",
-    "purescript-foreign": "^5.0.0",
-    "purescript-exceptions": "^4.0.0",
-    "purescript-arrays": "^5.3.0"
+    "purescript-prelude": "^5.0.0",
+    "purescript-typelevel-prelude": "^6.0.0",
+    "purescript-record": "^3.0.0",
+    "purescript-variant": "^7.0.1",
+    "purescript-nullable": "^5.0.0",
+    "purescript-foreign-object": "^3.0.0",
+    "purescript-foreign": "^6.0.0",
+    "purescript-exceptions": "^5.0.0",
+    "purescript-arrays": "^6.0.0"
   },
   "devDependencies": {
-    "purescript-assert": "^4.1.0",
-    "purescript-generics-rep": "^6.1.1"
+    "purescript-assert": "^5.0.0"
   }
 }

--- a/src/Simple/JSON.js
+++ b/src/Simple/JSON.js
@@ -1,3 +1,5 @@
 exports._parseJSON = JSON.parse;
 
 exports._undefined = undefined;
+
+exports._unsafeStringify = JSON.stringify;

--- a/test/EnumSumGeneric.purs
+++ b/test/EnumSumGeneric.purs
@@ -6,7 +6,7 @@ import Control.Alt ((<|>))
 import Control.Monad.Except (throwError)
 import Data.Either (Either, isRight)
 import Data.Generic.Rep (class Generic, Constructor(..), NoArguments(..), Sum(..), to)
-import Data.Generic.Rep.Show (genericShow)
+import Data.Show.Generic (genericShow)
 import Effect (Effect)
 import Foreign (Foreign)
 import Foreign as Foreign

--- a/test/Generic.purs
+++ b/test/Generic.purs
@@ -5,7 +5,7 @@ import Prelude
 import Control.Alt ((<|>))
 import Data.Either (Either, isRight)
 import Data.Generic.Rep as GR
-import Data.Generic.Rep.Show (genericShow)
+import Data.Show.Generic (genericShow)
 import Effect (Effect)
 import Foreign (Foreign)
 import Foreign as Foreign

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Control.Monad.Except (runExcept)
 import Data.Bifunctor (lmap)
-import Data.Either (Either(..), either, fromLeft, isRight)
+import Data.Either (Either(..), either, isRight)
 import Data.List (List(..), (:))
 import Data.List.NonEmpty (NonEmptyList(..))
 import Data.Maybe (Maybe)
@@ -15,7 +15,6 @@ import Effect (Effect)
 import Effect.Exception (throw)
 import Foreign (Foreign, ForeignError(..), MultipleErrors)
 import Foreign.Object (Object)
-import Partial.Unsafe (unsafePartial)
 import Simple.JSON (class ReadForeign, class WriteForeign, parseJSON, readJSON, writeJSON)
 import Test.Assert (assertEqual)
 import Test.EnumSumGeneric as Test.EnumSumGeneric
@@ -98,8 +97,8 @@ main = do
 
   -- "fails with invalid JSON"
   let r1 = readJSON """{ "c": 1, "d": 2}"""
-  (unsafePartial $ fromLeft r1) `shouldEqual`
-    (NonEmptyList (NonEmpty (ErrorAtProperty "a" (TypeMismatch "Int" "Undefined")) ((ErrorAtProperty "b" (TypeMismatch "String" "Undefined")) : (ErrorAtProperty "c" (TypeMismatch "Boolean" "Number")) : (ErrorAtProperty "d" (TypeMismatch "array" "Number")) : Nil)))
+  r1 `shouldEqual`
+    (Left (NonEmptyList (NonEmpty (ErrorAtProperty "a" (TypeMismatch "Int" "Undefined")) ((ErrorAtProperty "b" (TypeMismatch "String" "Undefined")) : (ErrorAtProperty "c" (TypeMismatch "Boolean" "Number")) : (ErrorAtProperty "d" (TypeMismatch "array" "Number")) : Nil))))
   isRight (r1 :: E MyTest) `shouldEqual` false
 
   -- "works with missing Maybe fields by setting them to Nothing"
@@ -110,8 +109,8 @@ main = do
   let r3 = readJSON """
     { "a": "asdf" }
   """
-  (unsafePartial $ fromLeft r3) `shouldEqual`
-    (NonEmptyList (NonEmpty (ErrorAtProperty "b" (TypeMismatch "Nullable String" "Undefined")) Nil))
+  r3 `shouldEqual`
+    (Left (NonEmptyList (NonEmpty (ErrorAtProperty "b" (TypeMismatch "Nullable String" "Undefined")) Nil)))
   (isRight (r3 :: E MyTestNullable)) `shouldEqual` false
 
   -- roundtrips

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -3,7 +3,7 @@ module Test.Util where
 import Prelude
 
 import Prim.Row as Row
-import Prim.RowList (class RowToList, Cons, Nil, kind RowList)
+import Prim.RowList (class RowToList, Cons, Nil, RowList)
 import Record (get)
 import Type.Prelude (class IsSymbol, RLProxy(..), SProxy(..))
 
@@ -17,7 +17,7 @@ equal
   -> Boolean
 equal a b = equalFields (RLProxy :: RLProxy rs) a b
 
-class EqualFields (rs :: RowList) (row :: # Type) | rs -> row where
+class EqualFields (rs :: RowList Type) (row :: Row Type) | rs -> row where
   equalFields :: RLProxy rs -> Record row -> Record row -> Boolean
 
 instance equalFieldsCons


### PR DESCRIPTION
I was trying to get purescript-payload to work with PureScript 0.14.0 and that in turn required updating purescript-simple-json.
I've removed the dependency on purescript-globals which has been deprecated and fixed all Row/RowList issues due to changes in 0.14.0.
I've also removed purescript-generics-rep as a dependency as it is also deprecated and no longer needed.

Could this be merged in for a new release so it could be added to the latest PureScript package set?