### PR TITLE
Replace all instances of SProxy with Proxy and remove purescript-type…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,6 @@
   ],
   "dependencies": {
     "purescript-prelude": "^5.0.0",
-    "purescript-typelevel-prelude": "^6.0.0",
     "purescript-record": "^3.0.0",
     "purescript-variant": "^7.0.1",
     "purescript-nullable": "^5.0.0",

--- a/src/Simple/JSON.purs
+++ b/src/Simple/JSON.purs
@@ -39,7 +39,7 @@ import Data.Identity (Identity(..))
 import Data.List.NonEmpty (singleton)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Nullable (Nullable, toMaybe, toNullable)
-import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
+import Data.Symbol (class IsSymbol, reflectSymbol)
 import Data.Traversable (sequence, traverse)
 import Data.TraversableWithIndex (traverseWithIndex)
 import Data.Variant (Variant, inj, on)
@@ -56,7 +56,7 @@ import Prim.RowList (class RowToList, Cons, Nil, RowList)
 import Record (get)
 import Record.Builder (Builder)
 import Record.Builder as Builder
-import Type.Prelude (Proxy(..))
+import Type.Proxy (Proxy(..))
 
 -- | An alias for the Either result of decoding
 type E a = Either MultipleErrors a
@@ -227,7 +227,7 @@ instance readFieldsCons ::
         value <- withExcept' (readImpl =<< readProp name obj)
         pure $ Builder.insert nameP value
       rest = getFields tailP obj
-      nameP = SProxy :: SProxy name
+      nameP = Proxy :: Proxy name
       tailP = Proxy :: Proxy tail
       name = reflectSymbol nameP
       withExcept' = withExcept <<< map $ ErrorAtProperty name
@@ -280,7 +280,7 @@ instance readVariantCons ::
         (fail <<< ForeignError $ "Did not match variant tag " <> name)
     <|> readVariantImpl (Proxy :: Proxy tail) o
     where
-      namep = SProxy :: SProxy name
+      namep = Proxy :: Proxy name
       name = reflectSymbol namep
 
 -- -- | A class for writing a value into JSON
@@ -341,7 +341,7 @@ instance consWriteForeignFields ::
   ) => WriteForeignFields (Cons name ty tail) row from to where
   writeImplFields _ rec = result
     where
-      namep = SProxy :: SProxy name
+      namep = Proxy :: Proxy name
       value = writeImpl $ get namep rec
       tailp = Proxy :: Proxy tail
       rest = writeImplFields tailp rec
@@ -379,7 +379,7 @@ instance consWriteForeignVariant ::
       (writeVariantImpl (Proxy :: Proxy tail))
       variant
     where
-    namep = SProxy :: SProxy name
+    namep = Proxy :: Proxy name
     writeVariant value = unsafeToForeign
       { type: reflectSymbol namep
       , value: writeImpl value

--- a/test/EnumSumGeneric.purs
+++ b/test/EnumSumGeneric.purs
@@ -7,12 +7,13 @@ import Control.Monad.Except (throwError)
 import Data.Either (Either, isRight)
 import Data.Generic.Rep (class Generic, Constructor(..), NoArguments(..), Sum(..), to)
 import Data.Show.Generic (genericShow)
+import Data.Symbol (class IsSymbol, reflectSymbol)
 import Effect (Effect)
 import Foreign (Foreign)
 import Foreign as Foreign
 import Simple.JSON as JSON
 import Test.Assert (assert)
-import Type.Prelude (class IsSymbol, SProxy(..), reflectSymbol)
+import Type.Proxy (Proxy(..))
 
 enumReadForeign :: forall a rep
    . Generic a rep
@@ -44,7 +45,7 @@ instance constructorEnumReadForeign ::
        else throwError <<< pure <<< Foreign.ForeignError $
             "Enum string " <> s <> " did not match expected string " <> name
     where
-      name = reflectSymbol (SProxy :: SProxy name)
+      name = reflectSymbol (Proxy :: Proxy name)
 
 data Fruit
   = Abogado

--- a/test/Inferred.purs
+++ b/test/Inferred.purs
@@ -11,7 +11,7 @@ import Foreign as Foreign
 import Record as Record
 import Simple.JSON as JSON
 import Test.Assert (assert)
-import Type.Prelude (SProxy(..))
+import Type.Proxy (Proxy(..))
 
 type RecordWithEither =
   { apple :: Int
@@ -43,8 +43,8 @@ readRecordMisnamedField s = do
   inter <- JSON.readJSON s
   pure $ Record.rename grapeP cherryP inter
   where
-    grapeP = SProxy :: SProxy "grape"
-    cherryP = SProxy :: SProxy "cherry"
+    grapeP = Proxy :: Proxy "grape"
+    cherryP = Proxy :: Proxy "cherry"
 
 main :: Effect Unit
 main = do

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -2,10 +2,11 @@ module Test.Util where
 
 import Prelude
 
+import Data.Symbol (class IsSymbol)
 import Prim.Row as Row
 import Prim.RowList (class RowToList, Cons, Nil, RowList)
 import Record (get)
-import Type.Prelude (class IsSymbol, RLProxy(..), SProxy(..))
+import Type.Proxy (Proxy(..))
 
 -- | Check two records of the same type for equality.
 equal
@@ -15,10 +16,10 @@ equal
   => Record r
   -> Record r
   -> Boolean
-equal a b = equalFields (RLProxy :: RLProxy rs) a b
+equal a b = equalFields (Proxy :: Proxy rs) a b
 
 class EqualFields (rs :: RowList Type) (row :: Row Type) | rs -> row where
-  equalFields :: RLProxy rs -> Record row -> Record row -> Boolean
+  equalFields :: Proxy rs -> Record row -> Record row -> Boolean
 
 instance equalFieldsCons
   ::
@@ -29,8 +30,8 @@ instance equalFieldsCons
   ) => EqualFields (Cons name ty tail) row where
   equalFields _ a b = get' a == get' b && rest
     where
-      get' = get (SProxy :: SProxy name)
-      rest = equalFields (RLProxy :: RLProxy tail) a b
+      get' = get (Proxy :: Proxy name)
+      rest = equalFields (Proxy :: Proxy tail) a b
 
 instance equalFieldsNil :: EqualFields Nil row where
   equalFields _ _ _ = true


### PR DESCRIPTION
Minor cleanup. Looks like SProxy is deprecated as well so I've replaced all instances of it with Proxy.
And I removed purescript-typelevel-prelude as a dependency as everything needed is already in purescript-prelude.