### PR TITLE
[seq] add support for Data.Sequence.Seq a

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.psc*
 /.purs*
 /.psa*
+/.spago

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
     "purescript-foreign-object": "^3.0.0",
     "purescript-foreign": "^6.0.0",
     "purescript-exceptions": "^5.0.0",
-    "purescript-arrays": "^6.0.0"
+    "purescript-arrays": "^6.0.0",
+    "purescript-sequences": "^3.0.2"
   },
   "devDependencies": {
     "purescript-assert": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "purescript-simple-json",
+  "main": "index.js",
+  "repository": "https://github.com/justinwoo/purescript-simple-json",
+  "author": "Przemek Kaminski <pk@intrepidus.pl>",
+  "license": "MIT",
+  "devDependencies": {
+    "purescript": "^0.14.2",
+    "spago": "^0.20.3"
+  }
+}

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,28 @@
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.2-20210622/packages.dhall sha256:c4949646febb03c7b1f329c9f48921c3a1e6afee133330fd24b5aa4a88112973
+
+let addons =
+  { sequences =
+    { dependencies =
+      [ "arrays"
+      , "assert"
+      , "console"
+      , "effect"
+      , "lazy"
+      , "maybe"
+      , "newtype"
+      , "nonempty"
+      , "partial"
+      , "prelude"
+      , "profunctor"
+      , "psci-support"
+      , "tuples"
+      , "unfoldable"
+      , "unsafe-coerce"
+      ]
+    , repo = "https://github.com/hdgarrood/purescript-sequences"
+    , version = "v3.0.2"
+    }
+  }
+
+in  (upstream // addons)

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,42 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+
+Need help? See the following resources:
+- Spago documentation: https://github.com/purescript/spago
+- Dhall language tour: https://docs.dhall-lang.org/tutorials/Language-Tour.html
+
+When creating a new Spago project, you can use
+`spago init --no-comments` or `spago init -C`
+to generate this file without the comments in this block.
+-}
+{ name = "simple-json"
+, dependencies =
+  [ "arrays"
+  , "assert"
+  , "bifunctors"
+  , "console"
+  , "control"
+  , "effect"
+  , "either"
+  , "exceptions"
+  , "foldable-traversable"
+  , "foreign"
+  , "foreign-object"
+  , "identity"
+  , "lists"
+  , "maybe"
+  , "nonempty"
+  , "nullable"
+  , "partial"
+  , "prelude"
+  , "psci-support"
+  , "record"
+  , "sequences"
+  , "transformers"
+  , "typelevel-prelude"
+  , "variant"
+  ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+}


### PR DESCRIPTION
Hello,

I'm not sure if you're interested, but I added `Data.Sequence` read/write support. This is useful alongside `Array` sometimes. Or do you suggest some other approach, eg. converting data to `Array` before serializing/deserializing?